### PR TITLE
Fix unsafe check, add tests.

### DIFF
--- a/lib/shellescape/main.py
+++ b/lib/shellescape/main.py
@@ -4,7 +4,7 @@
 import re
 
 
-_find_unsafe = re.compile(r'[a-zA-Z0-9_^@%+=:,./-]').search
+_find_unsafe = re.compile(r'[^a-zA-Z0-9_^@%+=:,./-]').search
 
 
 def quote(s):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -8,3 +8,16 @@ esc_string = quote(test_string)
 print(esc_string)
 esc_two_string = quote(esc_string)
 print(esc_two_string)
+
+def t(s, expected):
+    quoted = quote(s)
+    print '%s --> %r' % (s, quoted)
+    assert quoted == expected, 'Quoting %r gave %r, not %r' % (s, quoted, expected)
+
+
+t('"', "'\"'")
+t(' ', "' '")
+t(';', "';'")
+t(test_string, "'ls -l somefile; '\"'\"'rm -rf dir'")
+t(esc_string, "''\"'\"'ls -l somefile; '\"'\"'\"'\"'\"'\"'\"'\"'rm -rf dir'\"'\"''")
+


### PR DESCRIPTION
The logic was backwards here - it would only quote strings that had at least one safe character in it.  A string with only unsafe charactes would not be quoted.  String with a mix of characters would be quoted anyway, which is probably why nobody really noticed or cared about this.

This should fix that.